### PR TITLE
Fix handle_othre callback to implement without socket send any message

### DIFF
--- a/src/gen_smtp_server_session.erl
+++ b/src/gen_smtp_server_session.erl
@@ -91,7 +91,7 @@
 -callback handle_VRFY(Address :: binary(), State :: state()) ->
     {'ok', string(), state()} | {'error', string(), state()}.
 -callback handle_other(Verb :: binary(), Args :: binary(), state()) ->
-                          {string(), state()}.
+                          {string(), state()} | {'ok', state()}.
 -callback handle_info(Info :: term(), State :: term()) ->
     {noreply, NewState :: term()} |
     {noreply, NewState :: term(), timeout() | hibernate} |
@@ -622,9 +622,13 @@ handle_request({<<"STARTTLS">>, _Args}, #state{socket = Socket} = State) ->
 	socket:send(Socket, "501 Syntax error (no parameters allowed)\r\n"),
 	{ok, State};
 handle_request({Verb, Args}, #state{socket = Socket, module = Module, callbackstate = OldCallbackState} = State) ->
-	{Message, CallbackState} = Module:handle_other(Verb, Args, OldCallbackState),
-	socket:send(Socket, [Message, "\r\n"]),
-	{ok, State#state{callbackstate = CallbackState}}.
+	case Module:handle_other(Verb, Args, OldCallbackState) of
+		{ok, CallbackState} ->
+			{ok, State#state{callbackstate = CallbackState}};
+		{Message, CallbackState} ->
+			socket:send(Socket, [Message, "\r\n"]),
+			{ok, State#state{callbackstate = CallbackState}}
+	end.
 
 -spec(parse_encoded_address/1 :: (Address :: binary()) -> {binary(), binary()} | 'error').
 parse_encoded_address(<<>>) ->


### PR DESCRIPTION
I use this module under AWS ELB(Elastic Load Balancer), and enable PROXY protocol.
I wrote handle_other callback but did't send emails because this module send \r\n to smtp clients.
I fixed handle_other callback to implement without socket send any message.
So please approve this commit.
